### PR TITLE
Routes/friends/users

### DIFF
--- a/api/users.js
+++ b/api/users.js
@@ -1,6 +1,8 @@
 const express = require("express")
 const router = express.Router();
-const { User, Echoes } = require("../database"); 
+const { User, Echoes, Friends } = require("../database");
+const { Op } = require("sequelize");
+const { authenticateJWT } = require("../auth"); 
 
 router.get("/", async (req, res) => {
     try {
@@ -11,6 +13,45 @@ router.get("/", async (req, res) => {
     } catch (err) {
         res.status(500).json({ error: "Failed to fetch users" }); 
     }
+});
+// GET /api/users/me – return the logged-in user
+router.get("/me", authenticateJWT, async (req, res) => {
+  try {
+    const me = await User.findByPk(req.user.id, {
+      attributes: { exclude: ["password_hash"] },
+    });
+    if (!me) return res.status(404).json({ error: "User not found." });
+    res.json(me);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "Failed to load current user." });
+  }
+});
+
+
+// PATCH /api/users/:id  – update own profile
+router.patch("/:id", authenticateJWT, async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (req.user.id !== id) {
+    return res.status(403).json({ error: "You can only edit your own profile." });
+  }
+
+  // Update only fields that exist in your model
+  // (Your User model has username, bio, avatar_url, email, etc. — not firstName/lastName/img)
+  const allowed = ["username", "bio", "avatar_url", "email"];
+  const patch = {};
+  for (const k of allowed) if (req.body[k] !== undefined) patch[k] = req.body[k];
+
+  try {
+    const user = await User.findByPk(id);
+    if (!user) return res.status(404).json({ error: "User not found." });
+    await user.update(patch);
+    
+    res.json({ user });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "Failed to update profile." });
+  }
 });
 
 router.get("/:id", async (req, res) => {
@@ -23,6 +64,29 @@ router.get("/:id", async (req, res) => {
     } catch (err) {
         res.status(500).json({ error: "Failed to fetch user" })
     }
+});
+// GET /api/users/:id/friends – accepted friends of a user
+router.get("/:id/friends", async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  try {
+    const rows = await Friends.findAll({
+      where: {
+        [Op.or]: [{ user_id: id }, { friend_id: id }],
+        status: "accepted",
+      },
+    });
+    const otherIds = rows.map(r => (r.user_id === id ? r.friend_id : r.user_id));
+    const list = otherIds.length
+      ? await User.findAll({
+          where: { id: otherIds },
+          attributes: { exclude: ["password_hash"] },
+        })
+      : [];
+    res.json(list);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "Failed to fetch user's friends." });
+  }
 });
 
 router.get("/:id/echoes", async (req, res) => {


### PR DESCRIPTION
Summary
- Add universal Friends panel used from both Home and Profile (Friends / Requests / Sent / Find).
- Panel now reliably identifies the current user (prop → localStorage → GET /api/users/me) and normalizes IDs to numbers.
- Actions (accept / decline / cancel / block) refresh lists; Esc and overlay close panel.
- Profile: “Manage friends (N)” opens the panel; kept Edit; removed inline add/unfriend controls and inline friends list.
- Home: added FAB to open the same panel.

Backend
- NEW: GET /api/users/me — returns the authenticated user (uses authenticateJWT).
- NEW: PATCH /api/users/:id — self-edit only; allowed fields: username, bio, avatar_url, email; 403 when editing someone else.
- NEW: GET /api/users/:id/friends — returns accepted friends for any user.
- Existing friends endpoints leveraged:
  - GET /api/friends
  - POST /api/friends
  - PATCH /api/friends/:id/accept
  - PATCH /api/friends/:id/block
  - DELETE /api/friends/:id

Test plan
1) A → Find B → Add; B sees A under Requests (Home & Profile) → Accept → both show under Friends.
2) While pending: A sees B under Sent; B sees A under Requests (both entry points).
3) Profile “Manage friends (N)” matches count from /api/users/:id/friends.
4) Security: PATCH /api/users/:otherId → 403; PATCH /api/users/:meId updates only allowed fields.
